### PR TITLE
Updates AppStore Review URL

### DIFF
--- a/Classes/Classes/ABXAppStore.m
+++ b/Classes/Classes/ABXAppStore.m
@@ -13,7 +13,14 @@
 {
     if ([[[UIDevice currentDevice] systemVersion] compare:@"7.1" options:NSNumericSearch] != NSOrderedAscending) {
         // Since 7.1 we can throw to the review tab
-        NSString *url = [NSString stringWithFormat:@"http://itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?id=%@&pageNumber=0&ct=appbotReviewPrompt&at=11l4LZ&type=Purple%%252BSoftware&mt=8&sortOrdering=2", itunesId];
+
+// NOTE:
+// Updating iTunes URL, since this broke in Simplenote.
+//
+// NSString *url = [NSString stringWithFormat:@"http://itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?id=%@&pageNumber=0&ct=appbotReviewPrompt&at=11l4LZ&type=Purple%%252BSoftware&mt=8&sortOrdering=2", itunesId];
+//
+
+        NSString *url = [NSString stringWithFormat:@"http://itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?id=%@&pageNumber=0&sortOrdering=2&type=Purple+Software&mt=8", itunesId];
         [[UIApplication sharedApplication] openURL:[NSURL URLWithString:url]];
     }
     else {


### PR DESCRIPTION
In this PR we're updating the AppStore review URL.

We got reports that this wasn't working anymore in Simplenote. I managed to repro on Simplenote, but not on WPiOS.

[Reference here, third answer!](http://stackoverflow.com/questions/18905686/itunes-review-url-and-ios-7-ask-user-to-rate-our-app-appstore-show-a-blank-pag)

Needs review: @sendhil 
Thanks in advance!
